### PR TITLE
feat: fixes executor for interactive programs

### DIFF
--- a/pkg/executor/exec.go
+++ b/pkg/executor/exec.go
@@ -12,17 +12,21 @@ import (
 )
 
 type Executor struct {
-	done      chan os.Signal
-	logger    *slog.Logger
-	isRunning bool
+	done   chan os.Signal
+	logger *slog.Logger
+
+	mu      sync.Mutex
+	running *os.Process
+
+	isInteractive bool
 
 	newCmd func(context.Context) *exec.Cmd
-	mu     sync.Mutex
 }
 
 type ExecutorArgs struct {
-	Logger  *slog.Logger
-	Command func(context.Context) *exec.Cmd
+	Logger        *slog.Logger
+	Command       func(context.Context) *exec.Cmd
+	IsInteractive bool
 }
 
 func NewExecutor(args ExecutorArgs) *Executor {
@@ -34,65 +38,139 @@ func NewExecutor(args ExecutorArgs) *Executor {
 	}
 
 	return &Executor{
-		done:   done,
-		logger: args.Logger,
-		newCmd: args.Command,
-		mu:     sync.Mutex{},
+		done:          done,
+		logger:        args.Logger,
+		isInteractive: args.IsInteractive,
+		newCmd:        args.Command,
+		mu:            sync.Mutex{},
 	}
 }
 
+// ctx is process context
+func (ex *Executor) handleExits(ctx context.Context, cf context.CancelFunc) {
+	if ex.running == nil {
+		return
+	}
+
+	defer func() {
+		ex.running = nil
+		cf()
+	}()
+
+	select {
+	case <-ctx.Done():
+		// INFO: process exited
+		ex.logger.Debug("process terminated", "pid", ex.running.Pid)
+		// if ex.running != nil {
+		// }
+
+		if ex.isInteractive {
+			os.Exit(0)
+		}
+
+	case sig := <-ex.done:
+		// INFO: fwatcher exited
+		ex.logger.Debug("executor terminated", "received-signal", sig)
+		cf()
+	}
+
+	for len(ex.done) > 0 {
+		<-ex.done
+	}
+
+	if ex.isInteractive {
+		// INFO: interactive, only kill the process remains
+		ex.logger.Debug("[exec] killing process", "pid", ex.running.Pid)
+		ex.running.Signal(syscall.SIGKILL)
+		return
+	}
+
+	// INFO: non-interactive killing the entire child tree
+	ex.logger.Debug("[exec] killing process", "pid", ex.running.Pid)
+	if err := syscall.Kill(-ex.running.Pid, syscall.SIGKILL); err != nil {
+		if err.Error() != "no such process" {
+			ex.logger.Error("failed to kill process", "pid", ex.running.Pid, "err", err)
+		}
+	}
+}
+
+// DO NOT USE: does not work yet.
 func (ex *Executor) Exec() error {
 	ex.logger.Debug("[exec:pre] starting process")
 	ex.mu.Lock()
-	ex.isRunning = true
 
-	defer func() {
-		ex.isRunning = false
-		ex.mu.Unlock()
-	}()
+	defer ex.mu.Unlock()
 
 	ctx, cf := context.WithCancel(context.TODO())
 	defer cf()
 
 	cmd := ex.newCmd(ctx)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if !ex.isInteractive {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	}
 
 	if err := cmd.Start(); err != nil {
 		return err
 	}
 
-	go func() {
-		select {
-		case <-ctx.Done():
-			ex.logger.Debug("process terminated", "pid", cmd.Process.Pid)
-		case <-ex.done:
-			ex.logger.Debug("executor terminated", "pid", cmd.Process.Pid)
-		}
-		for len(ex.done) > 0 {
-			<-ex.done
-		}
+	ex.running = cmd.Process
 
-		ex.logger.Debug("[exec] killing process", "pid", cmd.Process.Pid)
-		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
-			if err.Error() != "no such process" {
-				ex.logger.Error("failed to kill process", "pid", cmd.Process.Pid, "err", err)
-			}
-		}
-	}()
+	go ex.handleExits(ctx, cf)
 
-	ex.logger.Debug("[exec:post] process running")
+	// defer func() { ex.running = nil }()
+	// go func() {
+	// 	select {
+	// 	case <-ctx.Done():
+	// 		// INFO: process exited
+	// 		ex.logger.Debug("process terminated", "pid", cmd.Process.Pid)
+	// 		<-time.After(1 * time.Second)
+	// 		if ex.isInteractive {
+	// 			os.Exit(0)
+	// 		}
+	//
+	// 	case sig := <-ex.done:
+	// 		// INFO: fwatcher exited
+	// 		ex.logger.Debug("executor terminated", "received-signal", sig)
+	// 		cf()
+	// 	}
+	//
+	// 	for len(ex.done) > 0 {
+	// 		<-ex.done
+	// 	}
+	//
+	// 	if cmd.Process != nil {
+	// 		ex.logger.Debug("[exec] killing process", "pid", cmd.Process.Pid)
+	// 		cmd.Process.Signal(syscall.SIGKILL)
+	// 	}
+	//
+	// 	ex.logger.Debug("[exec] killing process", "pid", cmd.Process.Pid)
+	// 	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+	// 		if err.Error() != "no such process" {
+	// 			ex.logger.Error("failed to kill process", "pid", cmd.Process.Pid, "err", err)
+	// 		}
+	// 	}
+	// }()
+
+	// ex.logger.Debug("[exec:post] process running")
 	if err := cmd.Wait(); err != nil {
+		ex.logger.Debug("cmd terminated with", "err", err)
+		err2, ok := err.(*exec.ExitError)
+		if ok {
+			ex.logger.Debug("cmd terminated with", "exit-code", err2.ExitCode())
+		}
+
 		if strings.HasPrefix(err.Error(), "signal:") {
 			ex.logger.Debug("wait terminated, received", "signal", err.Error())
 		}
 		ex.logger.Debug("while waiting, got", "err", err)
 	}
+	ex.logger.Debug("[exec] killed process", "pid", cmd.Process.Pid)
 
 	return nil
 }
 
 func (ex *Executor) Kill() {
-	if ex.isRunning {
+	if ex.running != nil {
 		ex.done <- os.Signal(syscall.SIGTERM)
 	}
 }


### PR DESCRIPTION
Closes #2 

## Fixes
- fixes watcher to clean up events queue, when closing, otherwise
- in case of large N number of events, task will get re-run again after closing

## Summary by Sourcery

Fix the executor to support interactive programs and ensure proper cleanup of the events queue in the watcher to prevent task re-runs. Enhance the executor's process handling and signal management.

New Features:
- Introduce support for interactive commands in the executor, allowing processes to be run interactively.

Bug Fixes:
- Fix the issue where the watcher did not clean up the events queue upon closing, preventing tasks from being re-run unnecessarily.

Enhancements:
- Refactor the executor to handle process exits more robustly, including proper cleanup and signal handling.